### PR TITLE
Add macOS support

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -5,19 +5,16 @@ import PackageDescription
 
 let package = Package(
     name: "MagicLoading",
+    platforms: [
+        .iOS(.v14),
+        .macOS(.v10_13)
+    ],
     products: [
-        // Products define the executables and libraries a package produces, and make them visible to other packages.
         .library(
             name: "MagicLoading",
             targets: ["MagicLoading"]),
     ],
-    dependencies: [
-        // Dependencies declare other packages that this package depends on.
-        // .package(url: /* package url */, from: "1.0.0"),
-    ],
     targets: [
-        // Targets are the basic building blocks of a package. A target can define a module or a test suite.
-        // Targets can depend on other targets in this package, and on products in packages this package depends on.
         .target(
             name: "MagicLoading",
             dependencies: []),

--- a/Sources/MagicLoading/MagicLoading.swift
+++ b/Sources/MagicLoading/MagicLoading.swift
@@ -1,7 +1,24 @@
+#if os(iOS)
 import UIKit
+#else
+import AppKit
+
+extension NSViewController {
+	fileprivate func loadViewIfNeeded() {
+		assert(Thread.isMainThread)
+		guard !isViewLoaded else { return }
+		_ = self.view  // Invokes loadView(), but only ever once.
+	}
+}
+#endif
 
 @propertyWrapper
 struct MagicViewLoading<WrappedValue> {
+#if os(iOS)
+	typealias ViewController = UIViewController
+#else
+	typealias ViewController = NSViewController
+#endif
 
 	private var stored: WrappedValue? = nil
 
@@ -18,7 +35,7 @@ struct MagicViewLoading<WrappedValue> {
 	/// and has remained consistently available. Since the technique informs static generation
 	/// of property wrapper "sugar", I think it's safe to rely upon it even for shipping code.
 	/// https://github.com/apple/swift-evolution/blob/main/proposals/0258-property-wrappers.md#referencing-the-enclosing-self-in-a-wrapper-type
-	static subscript<T: UIViewController>(
+	static subscript<T: ViewController>(
 		_enclosingInstance instance: T,
 		wrapped wrappedKeyPath: ReferenceWritableKeyPath<T, WrappedValue>,
 		storage storageKeyPath: ReferenceWritableKeyPath<T, Self>

--- a/Tests/MagicLoadingTests/MagicLoadingTests.swift
+++ b/Tests/MagicLoadingTests/MagicLoadingTests.swift
@@ -1,6 +1,7 @@
 import XCTest
 @testable import MagicLoading
 
+#if os(iOS)
 class MagicWrappedVC: UIViewController {
 
 	@MagicViewLoading var button: UIButton
@@ -48,3 +49,4 @@ final class LoadableWrapperTests: XCTestCase {
 	}
 
 }
+#endif


### PR DESCRIPTION
That's a cool backport! I want to try that in my Mac apps, to be honest :)

This PR allows compiling for iOS or macOS.

I didn't yet duplicate the tests to see what you think of the approach, first. I'm not using conditional compilation often, so maybe this is a bad idea in general.

*Also* `swift test` doesn't actually run the iOS tests by default now. I need to research how to tell the `swift` CLI utility to use a platform/SDK 🤔