### PR TITLE
Fix the typealias name used within  in macOS.

### DIFF
--- a/Sources/MagicLoading/MagicLoading.swift
+++ b/Sources/MagicLoading/MagicLoading.swift
@@ -6,7 +6,7 @@ typealias PlatformViewController = UIViewController
 #else
 
 import AppKit
-typealias ViewController = NSViewController
+typealias PlatformViewController = NSViewController
 
 extension NSViewController {
 


### PR DESCRIPTION
In the current code, the MagicViewLoading cannot be compiled successfully when building for macOS, because `PlatformViewController` is not defined.