### PR TITLE
Make `MagicViewLoading` public.

### DIFF
--- a/Sources/MagicLoading/MagicLoading.swift
+++ b/Sources/MagicLoading/MagicLoading.swift
@@ -1,12 +1,12 @@
 #if os(iOS)
 
 import UIKit
-typealias PlatformViewController = UIViewController
+public typealias PlatformViewController = UIViewController
 
 #else
 
 import AppKit
-typealias ViewController = NSViewController
+public typealias ViewController = NSViewController
 
 extension NSViewController {
 
@@ -22,7 +22,7 @@ extension NSViewController {
 #endif
 
 @propertyWrapper
-struct MagicViewLoading<WrappedValue> {
+public struct MagicViewLoading<WrappedValue> {
 
 	private var stored: WrappedValue? = nil
 
@@ -39,7 +39,7 @@ struct MagicViewLoading<WrappedValue> {
 	/// and has remained consistently available. Since the technique informs static generation
 	/// of property wrapper "sugar", I think it's safe to rely upon it even for shipping code.
 	/// https://github.com/apple/swift-evolution/blob/main/proposals/0258-property-wrappers.md#referencing-the-enclosing-self-in-a-wrapper-type
-	static subscript<T: PlatformViewController>(
+	public static subscript<T: PlatformViewController>(
 		_enclosingInstance instance: T,
 		wrapped wrappedKeyPath: ReferenceWritableKeyPath<T, WrappedValue>,
 		storage storageKeyPath: ReferenceWritableKeyPath<T, Self>
@@ -57,7 +57,7 @@ struct MagicViewLoading<WrappedValue> {
 	@available(*, unavailable,
 		message: "This property wrapper is only available on classes because it accesses its container using reference semantics"
 	)
-	var wrappedValue: WrappedValue {
+	public var wrappedValue: WrappedValue {
 		get { fatalError() }
 		set { fatalError() }
 	}


### PR DESCRIPTION
To use `MagicViewLoading` type by importing `MagicLoading` module into a project via SwiftPM, the access control of the type has been changed to public.